### PR TITLE
Update _1_Calibrate_Z_Probe.g

### DIFF
--- a/SD Card Structure/Quad/macros/Printer Setup/_1_Calibrate_Z_Probe.g
+++ b/SD Card Structure/Quad/macros/Printer Setup/_1_Calibrate_Z_Probe.g
@@ -33,9 +33,10 @@ G4 P401
 M291 P"Slowly move the bed up until nozzle is touching. Press OK when done." S2 Z1
 
 G92 Z0 ; set the current Z position as 0
-G1 Z20 ; lower bed by 20mm
+G1 Z100 ; lower bed to 100mm from the nozzle; need plenty of room to deploy z probe which is takes more room on the quad mount!
 
-M291 P"Deploy the Z Probe if needed. Press OK when done." S2
+M291 P"Deploy the Z Probe if not deployed. Press OK when done." S2
+G1 Z20 ; raise the bed back to 20mm from the nozzle before starting the measurement.
 G30 S-1 ; this will measure the Z Probe Z offset from 0
 
 ;Beep 3 times
@@ -46,7 +47,7 @@ G4 P401
 M300 S600 P250
 G4 P401
 
-M291 P"Retract the Z Probe if needed. Press OK to continue." S2
+M291 P"Retract the Z Probe if it is still deployed. Press OK to continue." S2
 M291 P"Record the Z axis value displayed in the Machine Status and set the G31 Z value in machine_zprobe.g to the value recorded." S2
 M291 P"After the file has been saved run the _2_Set_Z_Endstop_Height.g macro" S2
 M291 P"These messages are also displayed on the g-code console screen." S2


### PR DESCRIPTION
The Promega Quad mount has a different Z Probe than the default print heads.  This Macro should have already been updated to reflect this!
The changes include: 
1> Lowering the bed to 100mm Z axis instead of 20mm so there is room for actual hands to get in there and pull the z probe out and put it into the other slot.
2> Since the bed was lowered to 100mm, it should be raised to 20mm quickly before probing is started so that probing doesn't take a lot longer than necessary.  This could easily be 10mm instead of 20.  I just put it back to 20mm because that is where the other macros for the other heads start from, so this makes it consistent with them.
3> I slightly changed the wording on the Deploy and Retract wait messages.

Both this macro and the 3rd one need to be edited and for similar reasons in order to get them to work with the Promega Quad