### PR TITLE
Update _3_Mesh_Bed.g

### DIFF
--- a/SD Card Structure/Quad/macros/Printer Setup/_3_Mesh_Bed.g
+++ b/SD Card Structure/Quad/macros/Printer Setup/_3_Mesh_Bed.g
@@ -18,7 +18,7 @@ G1 Z200 ; move the bed to 200mm from the nozzle
 G29 S2 ; Disable bed mesh
 G29 S2 ; Disable bed mesh
 
-G1 X200 Y200 Z20 F1500 ; center extruder and raise bed.
+G1 X200 Y200 Z100 F1500 ; center extruder and move the bed to Z 100 so there is room to deploy the Promega Quad Mount Z Probe
 
 ;Beep 3 times
 M300 S600 P250
@@ -28,8 +28,9 @@ G4 P401
 M300 S600 P250
 G4 P401
 
-M291 P"Deploy the Z Probe if needed. Press OK when done." S2
+M291 P"Deploy the Z Probe if it isn't already deployed. Press OK when done." S2
 M291 P"Bed Mesh starting. Make sure to turn off Heaters when done." S2
+G1 Z20 F1500 ; raise bed back to z 20mm from the nozzle so that the mesh procedure doesn't take longer than necessary.
 G32 ; Executes the bed mesh procedure defined in bed.g
 
 ;Finish song
@@ -57,3 +58,6 @@ M300 S3500 P200
 G4 P250
 M300 S3500 P200
 G4 P250
+
+G1 Z100 F1500 ; Move the bed to Z 100mm from the nozzle so that there is room to retract the z probe if desired.
+M291 P"Retract the Z Probe if it isn't already retracted and if you aren't going to re-run this macro. Press OK when done." S2


### PR DESCRIPTION
This setup macro also should have already been edited like this to allow room for the z probe to be deployed when using the Promega Quad Mount.   The Promega Quad Mount requires a LOT more room for you to get your hand in there, pull the long z probe mount out, and move it into place.

This line:  "G1 Z20 F1500 ;" might need to be removed (I don't remember right now if the beginning of the bed mesh starts by homing the axis... if it does home the axis then there is no need to raise the bed back to Z20 first.)