### PR TITLE
Update bed.g - Remove references to T1 and T2

### DIFF
--- a/SD Card Structure/Quad/sys/bed.g
+++ b/SD Card Structure/Quad/sys/bed.g
@@ -5,11 +5,7 @@
 M140 S60 ; set the bed to 60C, change depending on your desired bed temp
 M190 S60 ; wait for the bed to reach 60C, change depending on your desired bed temp
 M104 T0 S150 ; set the nozzle to 150C
-M104 T1 S150 ; set the nozzle to 150C
-M104 T2 S150 ; set the nozzle to 150C
 M109 T0 S150 ; wait for the nozzle to read 150C
-M109 T1 S150 ; wait for the nozzle to read 150C
-M109 T2 S150 ; wait for the nozzle to read 150C
 
 ; Clear any bed transform
 G29 S2 ; Does the same as M561!


### PR DESCRIPTION
There is no such tool as T1 and T2 in the Quad.  It is clear that M3D copied the configs for the quad from one of the other heads and failed to test it.  If they had tested it, at all, then these issues could have easily been fixed by someone that is supposed to be familiar with this code.  Instead, 3+ months after the Quad head was shipping to ProMega backers, I have had to find and fix these errors while I'm trying to just get my printer to work properly for the first time.   I have spent several days worth of hours just trying to get my first print to work properly and have spent so much of that time just fixing things that M3D has failed to delver.

I'm sure support would prefer to not read about my dissatisfaction, but I would prefer to NOT provide my problem solving and technical skills for free.  This unit has had so many defects straight from the manufacturer that it has been completely unusable until I troubleshoot (often with help, sometimes without) a whole host of problems.  I hope that this feedback reached back up into the company since the ways to contact them are so limited.   I would chew out a manager for the state of this project if I could get a hold of one for long enough.   Today is March 3th.  The first Quad Fusion heads were shipped in December (if my understanding is correct).  I received my printer at the end of January.   These problems that I am fixing in your code, uncompensated by you, should have been found and corrected in January or earlier.  Period.