### PR TITLE
Update _2_Set_Z_Endstop_Height.g

### DIFF
--- a/SD Card Structure/Quad/macros/Printer Setup/_2_Set_Z_Endstop_Height.g
+++ b/SD Card Structure/Quad/macros/Printer Setup/_2_Set_Z_Endstop_Height.g
@@ -4,8 +4,6 @@ M291 P"Setting Z endstop height, this will home the printer, heat the bed and no
 
 M140 S60 ; Start heating bed to 60c
 G10 P0 S150 ;turn on extruder
-G10 P1 S150 ;turn on extruder
-G10 P2 S150 ;turn on extruder
 
 G28 ; Home all
 G28 Z ; Home z


### PR DESCRIPTION
Under ";turn on extruder" section, remove the calls containing P1 and P2.   From what I understand from user DroneOn, the P1 and P2 actually refer to Tool 1 and Tool 2.... not really extruders.   The quad only has one tool:  T0, so P0 is what should be turned on. 

Credit for this fix goes to DroneOn.  I'm just submitting it for everyone else to benefit from it.