### PR TITLE
Update _3_Mesh_Bed.g

### DIFF
--- a/SD Card Structure/Quad/macros/Printer Setup/_3_Mesh_Bed.g
+++ b/SD Card Structure/Quad/macros/Printer Setup/_3_Mesh_Bed.g
@@ -4,8 +4,6 @@ M291 P"Meshing the bed, this will home the printer, heat the bed and nozzle and 
 
 M140 S60 ; Start heating bed to 60c
 G10 P0 S150 ;turn on extruder
-G10 P1 S150 ;turn on extruder
-G10 P2 S150 ;turn on extruder
 
 G28 ; Home all
 G28 Z ; Home z


### PR DESCRIPTION
Same thing as the other two setup macros:  Need to remove the call to P1 and P2 because those actually refer to Tool 1 and Tool 2 which don't exist for the Quad.  Credit goes to user DroneOn for pointing out this fix.  I'm just sharing it with everyone.  M3D: You really should have found and fixed these problems in December / January.  The fact that the most basic errors are present unfixed 3+ months later really tells me you don't care about supporting people that have supported you.   This tells me that you haven't actually followed your own instructions and used your own setup materials to properly setup a Quad Fusion ProMega Build yet.  If you had, these problems would have been found and fixed by you in 1 day instead of taking me many days of troubleshooting and help from others.  I'm really disappointed in you and it will prevent me from telling others to buy anything from you in the future until you decide that once a person buys from you that they deserve to receive a working printer with fully working instructions on how to set it up right out of the box.