### PR TITLE
Update machine_corexy_motions_settings.g

### DIFF
--- a/SD Card Structure/Quad/sys/machine_corexy_motion_settings.g
+++ b/SD Card Structure/Quad/sys/machine_corexy_motion_settings.g
@@ -1,5 +1,5 @@
 ; Setups up the motion limits of the CoreXY system.
 
-M203 X9000 Y9000 Z2300 E5000:5000 ; velocity
-M201 X3000 Y3000 Z75 E150:150 ; acceleration
-M566 X350 Y350 Z50 E60:60 ; jerk
+M203 X9000 Y9000 Z2300 E1800  ; velocity
+M201 X3000 Y3000 Z75 E240     ; acceleration
+M566 X350 Y350 Z50 E120       ; jerk


### PR DESCRIPTION
Credit goes to DroneOn.  He was explaining to me that these settings as they were written before were incomplete and that these are closer to what is needed here.  Makes sense to me seeing the obvious dual extruder portion of the line that shouldn't even be there for the Quad...or if it should, it should have 4 ratios, not 1 ratio.   I believe the single value to be correct and is what I'm using now.