### PR TITLE
Update confiig.g - Fixing comment

### DIFF
--- a/SD Card Structure/Quad/sys/config.g
+++ b/SD Card Structure/Quad/sys/config.g
@@ -22,10 +22,10 @@ G29 S1										; Load heightmap after power cycle
 ; --- SECTION: DRIVES (MOVEMENT SECTION) & ENDSTOPS ---
 
 M667 S1										; Enable coreXY mode
-M569 P0 S0 D3 V0							; Drive 0 goes forwards, CoreXY_1, stealth chop, disable spread cycle
+M569 P0 S0 D3 V0							; Drive 0 goes backwards, CoreXY_1, stealth chop, disable spread cycle
 M569 P1 S1 D3 V0							; Drive 1 goes forwards, CoreXY_2, stealth chop, disable spread cycle
 M569 P2 S1 D3 V0							; Drive 2 goes forwards, Z Motor, stealth chop, disable spread cycle
-M569 P3 S1 D3 V0                          	; Drive 3 (E0)
+M569 P3 S1 D3 V0                ; Drive 3 (E0)
 M569 P4 S1 D3 V0			 			  	; Drive 4 (E1)
 M569 P5 S1 D3 V0			 			  	; Drive 5 (E2)
 M569 P6 S1 D3 V0			 			  	; Drive 6 (E3)
@@ -33,7 +33,7 @@ M98 Pmachine_endstoptypes.g					; set endstop types
 M98 Pmachine_steppercurrent.g				; set stepper currents
 M98 Pmachine_stepperspeed.g					; set stepper speeds
 M98 Pmachine_axisdimension.g				; configure the axes dimensions
-M98 Pmachine_axissteps.g					; configure the axes steps per mm
+M98 Pmachine_axissteps.g					  ; configure the axes steps per mm
 M98 Pmachine_extruderstep.g					; configure the extruder steps
 G21											; Work in millimetres
 G90											; Set to absolute coordinates...


### PR DESCRIPTION
The direction of P0 is different from P1 and P2, so I can see there is an error in the comment.  Looking up that Mcode, it says that S0 is backwards and S1 is forwards.