### PR TITLE
Update machine_extruderstep.g -- 4 extruders!

### DIFF
--- a/SD Card Structure/Quad/sys/machine_extruderstep.g
+++ b/SD Card Structure/Quad/sys/machine_extruderstep.g
@@ -8,6 +8,6 @@
 
 M350 E16		; Confirming default 1/16 microstepping mode for calculation, in case firmware default changes
 
-M92 E2140 ; Extruder microteps/mm
+M92 E2340.8:2356.5:2236.3:2350.4 ; Extruder Steps/mm (Format: M92 Extruder0:Extruder1:Extruder2:Extruder3)
 
 M350 E128    ; Set microstepping mode to 1/128.


### PR DESCRIPTION
I submitted this once before.  This file should be using a M92 code with 4 stepper values, not just 1.   Even if it defaults the other 3 values to that same thing, that is "implied" and it should be specified in the format I'm showing.  That way a user has a better chance of seeing that there are 4 different steppers to configure here.

I could understand if you were going to do:

M92 E2140:E2140:E2140:E2140 ; Extruder microteps/mm (Format: M92 Extruder0:Extruder1:Extruder2:Extruder3)

You might say that what you have is "good enough" but I disagree.  If you use the above line, it at least shows the user that there are 4 values that need to be set.


On a separate but related to this file note:  It was suggested to me that 128 setting be turned off and 16 stepping be used for added torque at the extruder.  The person that told me said that 16 steps was accurate enough for extrusion.  What do you think?  I haven't submitted that change, but I am considering trying it.