### PR TITLE
Update config.g -  Extruder Motor Direction

### DIFF
--- a/SD Card Structure/Quad/sys/config.g
+++ b/SD Card Structure/Quad/sys/config.g
@@ -25,10 +25,10 @@ M667 S1										; Enable coreXY mode
 M569 P0 S0 D3 V0							; Drive 0 goes forwards, CoreXY_1, stealth chop, disable spread cycle
 M569 P1 S1 D3 V0							; Drive 1 goes forwards, CoreXY_2, stealth chop, disable spread cycle
 M569 P2 S1 D3 V0							; Drive 2 goes forwards, Z Motor, stealth chop, disable spread cycle
-M569 P3 S1 D3 V0                          	; Drive 3 (E0)
-M569 P4 S1 D3 V0			 			  	; Drive 4 (E1)
-M569 P5 S1 D3 V0			 			  	; Drive 5 (E2)
-M569 P6 S1 D3 V0			 			  	; Drive 6 (E3)
+M569 P3 S0 D3 V0 								; Drive 3 (E0)
+M569 P4 S0 D3 V0								; Drive 4 (E1)
+M569 P5 S0 D3 V0			 			  	; Drive 5 (E2)
+M569 P6 S0 D3 V0			 			  	; Drive 6 (E3)
 M98 Pmachine_endstoptypes.g					; set endstop types
 M98 Pmachine_steppercurrent.g				; set stepper currents
 M98 Pmachine_stepperspeed.g					; set stepper speeds


### PR DESCRIPTION
The extruder stepper motor direction is wrong.  You guys removed a large block out of machine_quad_tools.g and then put the wrong motor direction into config.g.    If this mistake was "live" for a day or two and one of you guys eventually found it, that would be one thing.

This mistake has been up for 18 days and it is clear to me that after you guys make massive changes to the SD Card Sturcture that no one there is actually taking the time to download the files that you expect your customers to use and at least trying them out to make sure they work.   This is simple QC work.    You should have someone working for you that checks for basic functionality.

Before this there were errors that prevented printing live for 3 months before I got around to correcting them for you.  This is not acceptable.   I don't mind submitting improvements and tweaks / minor corrections.  I'm glad to help with that.  However as a paying customer and user I should be able to expect to download a "basically functional" image from your SD Card Github, especially if it has been 18 days since it was updated in any meaningful way.  You've had plenty of time to do the most basic of test here.