### PR TITLE
Update homeall.g - Home Z first, then XY

### DIFF
--- a/SD Card Structure/Quad/sys/homeall.g
+++ b/SD Card Structure/Quad/sys/homeall.g
@@ -4,10 +4,10 @@
 
 ; Front left corner is (0,0)
 
-; ============ HOME X & HOME Y ==============
-
-M98 Phomex.g ; Run the homex.g file, also homes the Y axis
-
 ; ============ HOME Z ==============
 
 M98 Phomez.g ; Run the homez.g file
+
+; ============ HOME X & HOME Y ==============
+
+M98 Phomex.g ; Run the homex.g file, also homes the Y axis


### PR DESCRIPTION
When running the setup macro #2 A SECOND time, the bed was touching the nozzle.   The macro calls HOMEALL.  The fist thing it did was move the XY.  It should have homed Z first to make sure there was clearance for the nozzle.

I looked at homeall.g and found that it was homing xy first.   This is dangerous if the nozzle is touching the bed.  It is best to home Z first which automatically creates clearance and THEN home XY.